### PR TITLE
Add Gym Name and Team in Eggs & Raids

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -806,6 +806,14 @@ class Manager(object):
 
         gym_id = egg['id']
 
+        # Update Gym details (if they exist)
+        if gym_id not in self.__gym_info or gym['name'] != 'unknown':
+            self.__gym_info[gym_id] = {
+                "name": gym['name'],
+                "description": gym['description'],
+                "url": gym['url']
+            }
+        
         raid_end = egg['raid_end']
 
         # raid history will contains any raid processed
@@ -852,6 +860,8 @@ class Manager(object):
         time_str = get_time_as_str(egg['raid_end'], self.__timezone)
         start_time_str = get_time_as_str(egg['raid_begin'], self.__timezone)
         gym_info = self.__gym_info.get(gym_id, {})
+        team = egg['team']
+        team_name = self.__team_name[team]
 
         egg.update({
             "gym_name": self.__gym_info.get(gym_id, {}).get('name', 'unknown'),
@@ -864,7 +874,8 @@ class Manager(object):
             'begin_12h_time': start_time_str[1],
             'begin_24h_time': start_time_str[2],
             "dist": get_dist_as_str(dist),
-            'dir': get_cardinal_dir([lat, lng], self.__latlng)
+            'dir': get_cardinal_dir([lat, lng], self.__latlng),
+            'team': team_name
         })
 
         threads = []
@@ -883,6 +894,14 @@ class Manager(object):
             return
 
         gym_id = raid['id']
+        
+        # Update Gym details (if they exist)
+        if gym_id not in self.__gym_info or gym['name'] != 'unknown':
+            self.__gym_info[gym_id] = {
+                "name": gym['name'],
+                "description": gym['description'],
+                "url": gym['url']
+            }
 
         pkmn_id = raid['pkmn_id']
         raid_end = raid['raid_end']
@@ -959,6 +978,8 @@ class Manager(object):
         time_str = get_time_as_str(raid['raid_end'], self.__timezone)
         start_time_str = get_time_as_str(raid['raid_begin'], self.__timezone)
         gym_info = self.__gym_info.get(gym_id, {})
+        team = raid['team']
+        team_name = self.__team_name[team]        
 
         raid.update({
             'pkmn': name,
@@ -974,7 +995,8 @@ class Manager(object):
             "dist": get_dist_as_str(dist),
             'dir': get_cardinal_dir([lat, lng], self.__latlng),
             'quick_move': self.__move_name.get(quick_id, 'unknown'),
-            'charge_move': self.__move_name.get(charge_id, 'unknown')
+            'charge_move': self.__move_name.get(charge_id, 'unknown'),
+            'team': team_name
         })
 
         threads = []

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -809,9 +809,7 @@ class Manager(object):
         # Update Gym details (if they exist)
         if gym_id not in self.__gym_info or gym['name'] != 'unknown':
             self.__gym_info[gym_id] = {
-                "name": gym['name'],
-                "description": gym['description'],
-                "url": gym['url']
+                "name": egg['name']
             }
         
         raid_end = egg['raid_end']
@@ -898,9 +896,7 @@ class Manager(object):
         # Update Gym details (if they exist)
         if gym_id not in self.__gym_info or gym['name'] != 'unknown':
             self.__gym_info[gym_id] = {
-                "name": gym['name'],
-                "description": gym['description'],
-                "url": gym['url']
+                "name": raid['name']
             }
 
         pkmn_id = raid['pkmn_id']

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -807,7 +807,7 @@ class Manager(object):
         gym_id = egg['id']
 
         # Update Gym details (if they exist)
-        if gym_id not in self.__gym_info or gym['name'] != 'unknown':
+        if gym_id not in self.__gym_info or egg['name'] != 'unknown':
             self.__gym_info[gym_id] = {
                 "name": egg['name']
             }
@@ -894,7 +894,7 @@ class Manager(object):
         gym_id = raid['id']
         
         # Update Gym details (if they exist)
-        if gym_id not in self.__gym_info or gym['name'] != 'unknown':
+        if gym_id not in self.__gym_info or raid['name'] != 'unknown':
             self.__gym_info[gym_id] = {
                 "name": raid['name']
             }

--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -177,7 +177,9 @@ class RocketMap:
             'raid_end': raid_end,
             'raid_begin': raid_begin,
             'lat': float(data['latitude']),
-            'lng': float(data['longitude'])
+            'lng': float(data['longitude']),
+            "team": int(data['team']),
+            "name": data['name']
         }
 
         egg['gmaps'] = get_gmaps_link(egg['lat'], egg['lng'])
@@ -231,7 +233,9 @@ class RocketMap:
             'raid_end': raid_end,
             'raid_begin': raid_begin,
             'lat': float(data['latitude']),
-            'lng': float(data['longitude'])
+            'lng': float(data['longitude']),
+            "team": int(data['team']),
+            "name": data['name']
         }
 
         raid['gmaps'] = get_gmaps_link(raid['lat'], raid['lng'])


### PR DESCRIPTION
## Description
Changes to the processing of egg and raid webhooks to post gym name if found and team name.

## How Has This Been Tested?
Tested running on Monocle, using Monkeys fork. It should work however on any scanner that is sending the information to the webhook. I have not tested on a scanner not sending this information however, so I would suggest this needs to be done before merging.

## Screenshots (if appropriate):
https://ibb.co/iXVRDa
https://ibb.co/iK5tta

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)