### PR TITLE
Add missing twitter dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gevent==1.2.1
 gipc==0.6.0
 googlemaps==2.4.6
 pytz==2016.10
+twitter==1.17.1


### PR DESCRIPTION

## Description
Running start_pokealarm on a new machine attempts to pip install this dependency. Making it visible in requirements.txt.

## How Has This Been Tested?
1.  Get a new machine
2.  Clone PokeAlarm
3.  `sudo pip install -r requirements.txt`
4.  Attempt to `python start_pokealarm.py` as a non-root user
5.  Watch `start_pokealarm.py` blow up failing to pip install twitter
6.  Add the requested version of twitter to the requirements file and re-run `sudo pip install -r ...`
7.  Watch `start_pokealarm.py` work this time

## Screenshots (if appropriate):
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->

Should not require a wiki update, as the wiki already implies that you are not running as the root user.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.