### PR TITLE
Add new DTS for correct (EU) address formatting

### DIFF
--- a/PokeAlarm/LocationServices.py
+++ b/PokeAlarm/LocationServices.py
@@ -79,9 +79,13 @@ class LocationService(object):
             for item in result['address_components']:
                 for category in item['types']:
                     loc[category] = item['short_name']
-            details['street_num'] = loc.get('street_number', '???')
-            details['street'] = loc.get('route', 'unknown')
+
+            # Note: for addresses in squares and on unnamed roads, it's correct with blank numbers/streetnames
+            # so we leave this as blank instead of unknown/??? to avoid DTS looking weird
+            details['street_num'] = loc.get('street_number', '')
+            details['street'] = loc.get('route', '')
             details['address'] = "{} {}".format(details['street_num'], details['street'])
+            details['address_eu'] = "{} {}".format(details['street'], details['street_num'])  # EU use Street 123
             details['postal'] = loc.get('postal_code', 'unknown')
             details['neighborhood'] = loc.get('neighborhood', "unknown")
             details['sublocality'] = loc.get('sublocality', "unknown")


### PR DESCRIPTION

## Description
Address DTS has been changed a tiny bit. It now will return an empty value if street name or street number is unknown. This allows for streets that have no numbers (like squares) to show up correctly. 

Example: A pokemon in a "Awesome Square, Europe City" would show up as "Awesome Square ???, Europe" it will now show up correctly with no street number.
Likewise unnamed roads wont show up as "unknown" but simply an empty string (there are many such roads in my area)

Lastly, and most importantly: there's a new DTS called `<address_eu>` that will write out "Alphabet Street 123" as addresses is usually written in Europe/Most of the world(?)

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
Two reasons: 
- Addresses in the EU is not written like in the US where street numbers come first. I would make the default address DTS EU style, but for historical reason I guess it is better to introduce `address-eu` as a new shorthand
- Seems counter intuitive to proclaim road numbers as ??? simply because google has no number information on them. Likewise unnamed streets should not be named "unkown".

## How Has This Been Tested?
Tested locally with an area with multiple unnumbered streets and unnamed streets

## Screenshots (if appropriate):

## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [X] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [X] This change follows the code style of this project.
- [X] This change only changes what is necessary to the feature.
