### PR TITLE
add team name to raid alert

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -707,13 +707,17 @@ class Manager(object):
                 "url": gym['url']
             }
 
-        if self.__gym_settings['enabled'] is False:
-            log.debug("Gym ignored: notifications are disabled.")
-            return
-
         # Extract some basic information
         to_team_id = gym['new_team_id']
         from_team_id = self.__gym_hist.get(gym_id)
+
+        if from_team_id != to_team_id:
+            # Update gym's last known team
+            self.__gym_hist[gym_id] = to_team_id
+
+        if self.__gym_settings['enabled'] is False:
+            log.debug("Gym ignored: notifications are disabled.")
+            return
 
         # Doesn't look like anything to me
         if to_team_id == from_team_id:
@@ -723,8 +727,6 @@ class Manager(object):
         if self.__gym_settings['ignore_neutral'] and to_team_id == 0:
             log.debug("Gym update ignored: changed to neutral")
             return
-        # Update gym's last known team
-        self.__gym_hist[gym_id] = to_team_id
 
         # Ignore first time updates
         if from_team_id is None:
@@ -984,6 +986,9 @@ class Manager(object):
 
         gym_info = self.__gym_info.get(gym_id, {})
 
+        #team id saved in self.__gym_hist when processing gym
+        team_id = self.__gym_hist.get(gym_id, -1)
+
         raid.update({
             'pkmn': name,
             "gym_name": gym_info.get('name', 'unknown'),
@@ -999,7 +1004,8 @@ class Manager(object):
             'dir': get_cardinal_dir([lat, lng], self.__location),
             'quick_move': self.__locale.get_move_name(quick_id),
             'charge_move': self.__locale.get_move_name(charge_id),
-            'form': self.__locale.get_form_name(pkmn_id, raid_pkmn['form_id'])
+            'form': self.__locale.get_form_name(pkmn_id, raid_pkmn['form_id']),
+            'team': self.__locale.get_team_name(team_id)
         })
 
         threads = []

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -987,7 +987,7 @@ class Manager(object):
         gym_info = self.__gym_info.get(gym_id, {})
 
         #team id saved in self.__gym_hist when processing gym
-        team_id = self.__gym_hist.get(gym_id, -1)
+        team_id = self.__gym_hist.get(gym_id, '?')
 
         raid.update({
             'pkmn': name,
@@ -1005,7 +1005,8 @@ class Manager(object):
             'quick_move': self.__locale.get_move_name(quick_id),
             'charge_move': self.__locale.get_move_name(charge_id),
             'form': self.__locale.get_form_name(pkmn_id, raid_pkmn['form_id']),
-            'team': self.__locale.get_team_name(team_id)
+            'team_id': team_id,
+            'team_name': self.__locale.get_team_name(team_id)
         })
 
         threads = []


### PR DESCRIPTION
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->
<!--       PULL REQUESTS CREATED NOT USING ONE OF THE BELOW         --->
<!--      ISSUE TEMPLATES WILL BE CLOSED WITHOUT ANY RESPONSE       --->


<!--
 Please make all PRs to the dev branch. The dev branch will be
 periodically pulled into the master branch. This allows time for
 the changes and documentation to be tested before being exposed to
 a wider population.
--->

## Description
Add raid team name to raid alerts.

## Type of Change
<!-- Place a single 'x' into the correct box, ex: [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (would cause existing functionality to change)

## Motivation and Context
<!---
 Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.
-->
This gives more information on the current team controlling the raid. This information is useful because premiere balls are given based on the team controlling the raid. Gym team information is also extracted and saved earlier if gym notifications have been disabled.

## How Has This Been Tested?
This has been tested in a production environment with Discord notifications.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9146812/31547894-a49701b8-afee-11e7-9809-0598990577e8.png)



## Wiki Update
<!--
 Does this feature require an update to the wiki? If so, please submit
 the required change to https://github.com/RocketMap/PokeAlarmWiki.
 If your feature requires a wiki update, you may submit it for review
 but it will not be accepted until the wiki update is complete.
--->
- [x] This change requires an update to the Wiki.
- [ ] This change does not require an update to the Wiki.


## Checklist
- [x] This change follows the code style of this project.
- [x] This change only changes what is necessary to the feature.
